### PR TITLE
Server port listen's console log is now a call back

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -5,5 +5,6 @@ var app = function(req, res){
 };
 
 var port = process.env.PORT || 4000;
-var server = http.createServer(app).listen(port);
-console.log(`Server is listening on port: ${port}`);
+var server = http.createServer(app).listen(port, () => {
+  console.log(`Server is listening on port: ${port}`);
+});


### PR DESCRIPTION
Fix #66 

We are now calling the console.log in a callback provided as .listen's second argument