### PR TITLE
Change module.exports to export single functions instead of objects

### DIFF
--- a/src/handler.js
+++ b/src/handler.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require ('path');
-const TFLAPI = require('./tflAPI.js');
-const TFLLogic = require('./tflLogic.js');
+const TFLRequest = require('./tflAPI.js');
+const TFLSortData = require('./tflLogic.js');
 const request = require('request');
 
 const handler = module.exports = {};
@@ -43,8 +43,8 @@ handler.serveError = function (req, res){
 
 
 handler.serveTFL = function(req, res) {
-  TFLAPI.TFLRequest(request, function (err, data) {
-    var timesObject = TFLLogic.TFLSortData(err, data);
+  TFLRequest(request, function (err, data) {
+    var timesObject = TFLSortData(err, data);
     res.writeHead(200, { 'Content-Type': 'application/json'});
     res.end(JSON.stringify(timesObject));
   });

--- a/src/tflAPI.js
+++ b/src/tflAPI.js
@@ -14,6 +14,4 @@ const TFLRequest = (module, callback) => {
   });
 };
 
-module.exports = {
-  TFLRequest: TFLRequest
-}
+module.exports = TFLRequest;

--- a/src/tflLogic.js
+++ b/src/tflLogic.js
@@ -27,6 +27,4 @@ function TFLSortData(error, data) {
   }
 }
 
-module.exports = {
-  TFLSortData: TFLSortData
-}
+module.exports = TFLSortData;

--- a/tests/src/test.js
+++ b/tests/src/test.js
@@ -2,7 +2,7 @@ const test = require('tape');
 const shot = require('shot');
 const fs = require('fs');
 const router = require('../../src/router');
-const TFLLogic = require('../../src/tflLogic.js');
+const TFLSortData = require('../../src/tflLogic.js');
 
 // INITIAL TEST
 test('Initialise', (t) => {
@@ -17,11 +17,11 @@ test('Object filtering testing', (t) => {
   let expectedEE = {west: [['Westbound - Platform 1', 'loughton', 451]], east: []};
   let objWestEmpty = [{platformName: 'Eastbound - Platform 2', towards: 'loughton', timeToStation: 451, station: 'Bethnal Green', BrokenTrain: 101}];
   let expectedWE = {west: [], east: [['Eastbound - Platform 2', 'loughton', 451]]};
-  t.ok(typeof TFLLogic.TFLSortData(null,objWestEmpty) && typeof (TFLLogic.TFLSortData(null,objEastEmpty)) === 'object');
-  t.ok(Array.isArray(TFLLogic.TFLSortData(null,objEastEmpty).west));
-  t.deepEqual(TFLLogic.TFLSortData(null,emptyObject), expectedEmpty, 'Should return an object with two empy arrays!');
-  t.deepEqual(TFLLogic.TFLSortData(null,objWestEmpty), expectedWE, 'Should avoid BrokenTrain!');
-  t.deepEqual(TFLLogic.TFLSortData(null,objEastEmpty), expectedEE, 'Should avoid BrokenTrain!');
+  t.ok(typeof TFLSortData(null,objWestEmpty) && typeof (TFLSortData(null,objEastEmpty)) === 'object');
+  t.ok(Array.isArray(TFLSortData(null,objEastEmpty).west));
+  t.deepEqual(TFLSortData(null,emptyObject), expectedEmpty, 'Should return an object with two empy arrays!');
+  t.deepEqual(TFLSortData(null,objWestEmpty), expectedWE, 'Should avoid BrokenTrain!');
+  t.deepEqual(TFLSortData(null,objEastEmpty), expectedEE, 'Should avoid BrokenTrain!');
   t.end();
 });
 


### PR DESCRIPTION
Change module.exports statements so that we are exporting single functions and not objects, as we are only exporting one function per file
Ensure this change is reflected wherever these functions are referred to
Relates #62 #65